### PR TITLE
Create `Order.itemSubtotal` virtual field

### DIFF
--- a/script/seed.js
+++ b/script/seed.js
@@ -1,5 +1,7 @@
 'use strict'
 const {db, models: {User, Order, Product, OrderItem} } = require('../server/db')
+const sequelize = require('sequelize')
+const Op = sequelize.Op
 const debug = require('debug')
 const logger = debug('app:test:seed')
 
@@ -10,112 +12,115 @@ const Users = [{
   password: 'adrienne100',
   email: 'adriennescutellaro@gmail.com',
   isAdmin: true,
+  cartId: 1,
 }, {
   username: 'gracejones',
   name: 'Grace Jones',
   password: 'style',
   email: 'grace@bossbitch.net',
   isAdmin: false,
+  cartId: 2,
 }, {
   username: 'davidbowie',
   name: 'David Bowie',
   password: 'stardust',
   email: 'david@bowie.net',
   isAdmin: false,
+  cartId: 15,
 }, {
   username: 'annielennox',
   name: 'Annie Lennox',
   password: 'littlebird',
   email: 'annie@eurythmics.com',
   isAdmin: false,
+  cartId: 6,
 }, {
   username: 'prince',
   name: 'Prince',
   password: 'paisley',
   email: 'prince@therevolution.com',
-   isAdmin: false,
+  isAdmin: false,
+  cartId: 16,
 }, {
   username: 'ladygaga',
   name: 'Lady Gaga',
   password: 'joanne',
   email: 'stephanie@gaga.com',
   isAdmin: false,
+  cartId: 9,
 }, {
   username: 'tinaturner',
   name: 'Tina Turner',
   password: 'simplythebest',
   email: 'tina@turner.com',
   isAdmin: false,
+  cartId: 10,
 }, {
   username: 'stevienicks',
   name: 'Stevie Nicks',
   password: 'sorceress',
   email: 'snicks@fleetwood.mac',
   isAdmin: false,
+  cartId: 11,
 }, {
   username: 'georgemichael',
   name: 'George Michael',
   password: 'fatherfigure',
   email: 'george@wham.com',
   isAdmin: false,
+  cartId: 12,
 }, {
   username: 'samsmith',
   name: 'Sam Smith',
   password: 'theonlyone',
   email: 'sam@samsmith.com',
   isAdmin: false,
+  cartId: 13,
 }, {
   username: 'beyonce',
   name: 'Beyonce',
   password: 'queen',
   email: 'bey@beyhive.com',
   isAdmin: false,
+  cartId: 14,
 }]
 
 const Products = [{
-  id: 1,
   name: 'Studio Monitors',
   description: 'Clean and precise for mixing.',
   price: 29999,
   imageUrl: 'https://www.soundguys.com/wp-content/uploads/2020/06/PreSonus-Eris-3.5-studio-monitor-pair-lifestyle-image.jpg'
 }, {
-  id: 2,
   name: 'Subwoofer',
   description: 'So necessary.',
   price: 39999,
   imageUrl: 'https://www.hifihut.ie/media/catalog/product/cache/1/thumbnail/9df78eab33525d08d6e5fb8d27136e95/k/l/klipsch_r-100sw_subwoofer_-_black_a.jpg'
 }, {
-  id: 3,
   name: 'Center Channel Speaker',
   description: 'Hear that dialogue nice and clear.',
   price: 19999,
   imageUrl: 'https://www.mtx.com/c/thumbs/0004384_dcm-tfe60c-65-inch-2-way-100w-rms-8-ohm-center-channel-speaker-cherry-finish.jpeg'
 }, {
-  id: 4,
   name: 'Surround Speakers',
   description: 'These are how you know spaceships are flying left to right.',
   price: 24999,
   imageUrl: 'https://www.techgadgetguides.com/wp-content/uploads/2019/07/1-9.jpg'
 }, {
-  id: 5,
   name: 'Dolby Atmos Ceiling Speakers',
   description: 'These fire up when the movie monsters are looming overhead.',
   price: 34999,
   imageUrl: 'https://audioxpress.com/assets/upload/images/TriadSpeakersBronzeInWallSubsWeb.jpg'
 }, {
-  id: 6,
   name: 'Fancy Headphones',
   description: 'More money than you should probably spend, but you will feel really fancy.',
   price: 99999,
   imageUrl: 'https://www.dailyhawker.com/wp-content/uploads/2020/08/Audeze-LCD-3-most-Expensive-Headphones-in-the-World-1024x1024.jpg'
 }, {
-  id: 7,
   name: 'Cute Bluetooth Speaker for Kids',
   description: 'It looks cute, sounds okay, and is going to drive you crazy.',
   price: 4999,
   imageUrl: 'https://wws-weblinc.netdna-ssl.com/product_images/jbl-jr-pop-portable-bluetooth-speaker-for-kids/Pink/5c3357f8e9b6cc4f5806bef9/zoom.jpg'
 }, {
-  id: 8,
   name: 'Bluetooth Beach Speaker',
   description: 'It sands nice!',
   price: 9999,
@@ -149,6 +154,27 @@ const Orders = [{
 }, {
   status: 'open',
   userId: 6
+}, {
+  status: 'open',
+  userId: 7
+}, {
+  status: 'open',
+  userId: 8
+}, {
+  status: 'open',
+  userId: 9
+}, {
+  status: 'open',
+  userId: 10
+}, {
+  status: 'open',
+  userId: 11
+}, {
+  status: 'open',
+  userId: 3
+}, {
+  status: 'open',
+  userId: 5
 }]
 
 const OrderItems = [{
@@ -256,9 +282,8 @@ async function seed() {
     throw(err)
   }
 
-  // Creating Users
   try {
-    await User.bulkCreate(Users)
+    await User.bulkCreate(Users, { hooks: false })
     await Product.bulkCreate(Products)
     await Order.bulkCreate(Orders)
     await OrderItem.bulkCreate(OrderItems)
@@ -296,7 +321,7 @@ async function runSeed() {
   any errors that might occur inside of `seed`.
 */
 if (module === require.main) {
-  debug.enable('app:test:seed')
+  if (!debug.enabled) debug.enable('app:test:seed')
   runSeed()
 }
 

--- a/server/api/users.spec.js
+++ b/server/api/users.spec.js
@@ -2,30 +2,62 @@
 
 const {expect} = require('chai')
 const request = require('supertest')
-const { db, models: { User } } = require('../db')
-const seed = require('../../script/seed');
+const { db, models: { User, Product } } = require('../db')
 const app = require('../app')
 
 describe('User routes', () => {
   let user;
-  
+  let token;
+
   before(async() => {
-    await seed();
-    user = await User.findOne({ where: { isAdmin: true }})
+    await db.sync({ force: true })
+    user = await User.create({
+      name: 'test user',
+      username: 'testuser',
+      email: 'test@user.com',
+      password: 'password',
+      isAdmin: true
+    })
+    token = user.generateToken();
     return user
   })
 
-  describe('/api/users/', () => {
-    it('GET /api/users', () => {
-      const token = user.generateToken();
-      return request(app)
+  describe('/users', () => {
+    it('GET', () => request(app)
         .get('/api/users')
         .set('authorization', token)
         .expect(200)
         .then(res => {
           expect(res.body).to.be.an('array');
-          expect(res.body.length).to.equal(11);
+          expect(res.body.length).to.equal(1);
         })
+    )
+  })
+
+  describe('/user/1', () => {
+    before(async () => {
+      const products = await Product.bulkCreate([{
+        name: 'product 1',
+        price: 1000,
+      }, {
+        name: 'product 2',
+        price: 2000,
+      }])
+      const cart = await user.getCart()
+      await cart.setProducts(products)
     })
+
+    it('GET', () => request(app)
+      .get('/api/users/1')
+      .set('authorization', token)
+      .expect(200)
+      .then(async res => {
+        expect(res.body).to.be.an('object')
+        const userJson = res.body
+        expect(userJson.name).to.equal('test user')
+        expect(userJson.cart).to.have.length(2)
+      })
+
+    )
   }) // end describe('/api/users')
 }) // end describe('User routes')

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -10,6 +10,15 @@ const OrderItem = require('./models/OrderItem')
 //associations could go here!
 User.hasMany(Order)
 Order.belongsTo(User, { allowNull: false })
+// Order.hasOne(User, {
+//   as: 'cart',
+//   constraints: false,
+// })
+User.belongsTo(Order, {
+  as: 'cart',
+  constraints: false,
+})
+
 Product.belongsToMany(Order, { through: OrderItem })
 Order.belongsToMany(Product, { through: OrderItem })
 

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -10,10 +10,6 @@ const OrderItem = require('./models/OrderItem')
 //associations could go here!
 User.hasMany(Order)
 Order.belongsTo(User, { allowNull: false })
-// Order.hasOne(User, {
-//   as: 'cart',
-//   constraints: false,
-// })
 User.belongsTo(Order, {
   as: 'cart',
   constraints: false,

--- a/server/db/models/Order.js
+++ b/server/db/models/Order.js
@@ -5,6 +5,14 @@ const Order = db.define('order', {
     status: {
         type: Sequelize.ENUM('open', 'fulfilled', 'shipped', 'cancelled'),
         defaultValue: 'open',
+    },
+    itemSubtotal: {
+        type: Sequelize.VIRTUAL,
+        async get() {
+            const items = await this.getProducts()
+            // item subtotal = product.price * product.order_item.quantity
+            return items.reduce((total, p) => total + (p.price * p.order_item.quantity), 0)
+        }
     }
 })
 

--- a/server/db/models/Order.spec.js
+++ b/server/db/models/Order.spec.js
@@ -1,0 +1,46 @@
+const {expect} = require('chai')
+const { db, models: { Order, User, Product } } = require('../index')
+
+describe('Order model', () => {
+    before(async () => await db.sync({ force: true }))
+
+    describe('Virtual fields', () => {
+        let user
+        let products
+
+        before(async () => {
+            user = await User.create({
+                username: 'testuser',
+                name: 'test user',
+                password: 'whatever',
+                email: 'u@example.com',
+            })
+            
+            products = await Product.bulkCreate([
+                {
+                    name: 'product 1',
+                    price: 1000,
+                }, {
+                    name: 'product 2',
+                    price: 2000,
+                }, {
+                    name: 'product 3',
+                    price: 3000,
+                }
+            ])
+        })
+    
+        describe('itemSubtotal', () => {
+            let cart
+
+            before(async () => {
+                cart = await user.getCart()
+                await cart.setProducts([1,2,3])        
+            })
+
+            it('calculates item subtotal for all products in Order', async () => {
+                expect(await cart.itemSubtotal).to.equal(6000)
+            })
+        })
+    })
+})

--- a/server/db/models/OrderItem.js
+++ b/server/db/models/OrderItem.js
@@ -3,7 +3,8 @@ const db = require('../db')
 
 const OrderItems = db.define('order_item', {
     quantity: {
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
+        defaultValue: 1,
       },
     salePrice: {
         type: Sequelize.INTEGER

--- a/server/db/models/User.js
+++ b/server/db/models/User.js
@@ -18,6 +18,9 @@ const User = db.define('user', {
   password: {
     type: Sequelize.STRING,
     allowNull: false,
+    set(pw) {
+      this.setDataValue('password', bcrypt.hashSync(pw, SALT_ROUNDS))
+    }
   },
   email: {
     type: Sequelize.STRING,
@@ -30,10 +33,6 @@ const User = db.define('user', {
     type: Sequelize.BOOLEAN,
     defaultValue: false,
   },
-  // cartId: {
-  //   type: Sequelize.INTEGER,
-  //   // references: { model: { tableName: 'Order' } },
-  // }
 })
 
 module.exports = User
@@ -48,30 +47,6 @@ User.prototype.correctPassword = function(candidatePwd) {
 
 User.prototype.generateToken = function() {
   return jwt.sign({id: this.id}, process.env.JWT)
-}
-
-User.prototype.getCart = async function() {
-  // console.log(await this.getOrders())
-  const orders = await this.getOrders({
-    where: {
-      [Sequelize.Op.and]: [
-        {userId: this.id},
-        {status: 'open'}
-      ]
-    },
-    include: 'products'
-  })
-  const products = await orders[0].getProducts()
-  console.log(products)
-  return products.map(p => ({ 
-    id: p.id,
-    name: p.name,
-    price: p.price,
-    salePrice: p.order_item.salePrice,
-    quantity: p.order_item.quantity,
-    description: p.description,
-    imageUrl: p.imageUrl,
-  }))
 }
 
 /**
@@ -110,13 +85,13 @@ User.findByToken = async function(token) {
 /**
  * hooks
  */
-const hashPassword = async(user) => {
-  //in case the password has been changed, we want to encrypt it with bcrypt
-  if (user.changed('password')) {
-    user.password = await bcrypt.hash(user.password, SALT_ROUNDS);
-  }
+
+// assures that every user has a cart
+const afterCreate = async (user) => {
+  // if user has a cartId, cart already exists and nothing to do
+  if (user.cartId) return
+
+  await user.createCart({ userId: user.id })
 }
 
-User.beforeCreate(hashPassword)
-User.beforeUpdate(hashPassword)
-User.beforeBulkCreate(users => Promise.all(users.map(hashPassword)))
+User.afterCreate(afterCreate)

--- a/server/db/models/User.spec.js
+++ b/server/db/models/User.spec.js
@@ -3,30 +3,36 @@
 const {expect} = require('chai')
 const { db, models: { User } } = require('../index')
 const jwt = require('jsonwebtoken');
-const seed = require('../../../script/seed');
 
 describe('User model', () => {
-  let users;
+  let user;
+
   before(async () => {
-    await seed()
-    users = await User.findAll()
-    return users
+    await db.sync({ force: true })
+    user = await User.create({
+      username: 'lucy',
+      password: 'loo'
+    })
+  });
+
+  describe('Relations', () => {
+    describe('cart', () => {
+      it('is created when user is created', async () => {
+        expect(user.cartId).to.be.greaterThanOrEqual(0)
+        expect((await user.getCart()).id).to.equal(user.cartId)
+      })
+    })
   })
 
   describe('instanceMethods', () => {
     describe('generateToken', () => {
-      it('returns a token with the id of the user', async() => {
-        const token = await users[0].generateToken();
+      it('returns a token with the id of the user', async () => {
+        const token = await user.generateToken();
         const { id } = await jwt.verify(token, process.env.JWT);
-        expect(id).to.equal(users[0].id);
+        expect(id).to.equal(user.id);
       })
     }) // end describe('correctPassword')
     describe('authenticate', () => {
-      let user;
-      before(async()=> user = await User.create({
-        username: 'lucy',
-        password: 'loo'
-      }));
       describe('with correct credentials', ()=> {
         it('returns a token', async() => {
           const token = await User.authenticate({


### PR DESCRIPTION
This PR is huge and I apologize, but it _will_ make life easier on the backend and result in less/dryer code overall.  Here's what it does:
- adds the cart as a first-class concept on the User model, making it possible to get a user's cart by simply calling `.getCart()`
- speeds up test setup by having each database integration suite define its own, minimal test data set
- makes use of `cart.addProducts()` and friends
- replaces hooks methods for handling passwords (which were bloated) in favor of using a custom setter method on the User.password field
- includes test of single-user GET request (in order to exercise cart-fetching code)
- adds `Order.itemSubtotal` field and includes test of functionality

Resolves #57 