### PR TITLE
Load Cart Safely

### DIFF
--- a/client/store/auth.spec.js
+++ b/client/store/auth.spec.js
@@ -11,7 +11,7 @@ import history from '../history'
 const middlewares = [thunkMiddleware]
 const mockStore = configureMockStore(middlewares)
 
-describe('thunk creators', () => {
+describe('/auth', () => {
   let store
   let mockAxios
 
@@ -37,7 +37,7 @@ describe('thunk creators', () => {
     store.clearActions()
   })
 
-  describe('me', () => {
+  describe('/me', () => {
     describe('with valid token', () => {
       beforeEach(() => {
         global.window = {
@@ -80,12 +80,13 @@ describe('thunk creators', () => {
     })
   })
 
-  describe('logout', () => {
-    it('logout: eventually dispatches the SET_AUTH action withan empty object', async () => {
+  describe('/logout', () => {
+    it('eventually dispatches the SET_AUTH action with an empty object', async () => {
       mockAxios.onPost('/auth/logout').replyOnce(204)
       await store.dispatch(logout())
       const actions = store.getActions()
-      expect(actions[0].type).to.be.equal('SET_AUTH')
+      const target = actions.filter((a) => a.type === "SET_AUTH")[0]
+      expect(target).to.be.ok
       expect(history.location.pathname).to.be.equal('/login')
     })
   })

--- a/client/store/singleUser.js
+++ b/client/store/singleUser.js
@@ -2,8 +2,12 @@ const cartStorageKey = "CART"
 
 const getLocalCart = () => {
   if (typeof window !== 'undefined') {
-    const cart = window.localStorage.getItem(cartStorageKey)
-    if (cart) return JSON.parse(cart);
+    try {
+      const cart = window.localStorage.getItem(cartStorageKey)
+      if (cart) return JSON.parse(cart);
+    } catch (error) {
+      console.debug('Reading cart from local storage failed', error)
+    }
   }
   return [];
 }

--- a/client/store/singleUser.spec.js
+++ b/client/store/singleUser.spec.js
@@ -59,10 +59,20 @@ describe("singleUser", () => {
     });
 
     describe("add to cart", () => {
-      it(`does not call fetch for unauthenticated users`, () => {
+      it(`uses only local storage for unauthenticated users`, () => {
+        let getItemCalls = 0
         global.window = {
           localStorage: {
-            getItem: () => {},
+            getItem: (key) => {
+              console.log(`getItem(${key})`)
+              getItemCalls++
+              switch (key) {
+                case 'token':
+                  return
+                case 'CART':
+                  return(JSON.stringify([]))
+              }
+            },
           },
         };
 
@@ -80,15 +90,24 @@ describe("singleUser", () => {
 
         return store.dispatch(addToCart({}, 2)).then(() => {
           // return of async actions
-          expect(store.getActions()).to.deep.equal(expectedActions);
-          expect(fetchMock.called()).to.equal(false);
+          expect(store.getActions()).to.deep.equal(expectedActions, 'incorrect actions');
+          expect(fetchMock.called()).to.equal(false, 'fetch was called');
+          // only 1 because the get-cart call is missed by mocha -- it happens at load time, before test run time
+          expect(getItemCalls).to.equal(1, 'token not checked')
         });
       });
 
       it(`reports changes to the backend for authenticated users`, () => {
         global.window = {
           localStorage: {
-            getItem: () => "token",
+            getItem: (key) => {
+              switch (key) {
+                case "token":
+                  return "token"
+                case "CART":
+                  return []
+              }
+            },
             setItem: () => {},
           },
         };
@@ -107,7 +126,7 @@ describe("singleUser", () => {
 
         return store.dispatch(addToCart({}, 2)).then(() => {
           // return of async actions
-          expect(store.getActions()).to.deep.equal(expectedActions);
+          expect(store.getActions()).to.deep.equal(expectedActions, "actions do not match");
           expect(fetchMock.called()).to.equal(true);
         });
       });


### PR DESCRIPTION
App was crashing when local storage returned bad data for the cart. This catches the error thrown when bad data is read, and returns an empty cart if the one in local storage is corrupted.

Resolves #81 